### PR TITLE
fix: prevent downloading of same version again

### DIFF
--- a/src/cmd/install.rs
+++ b/src/cmd/install.rs
@@ -37,9 +37,7 @@ impl super::Command for Install {
             Some(r) => {
                 let dwnld = Downloader::new(&r, &config);
 
-                let buf = dwnld.download()?;
-
-                let dest = dwnld.install(buf)?;
+                let dest = dwnld.download()?;
 
                 if is_lts {
                     let alias = self.version.to_string();

--- a/src/cmd/latest.rs
+++ b/src/cmd/latest.rs
@@ -16,8 +16,7 @@ impl super::Command for Latest {
         let release = releases.latest()?;
 
         let dwnld = Downloader::new(release, &config);
-        let buf = dwnld.download()?;
-        let dest = dwnld.install(buf)?;
+        let dest = dwnld.download()?;
 
         crate::symlink::symlink_to(&dest, &config.alias_dir().join(&ALIAS))?;
 

--- a/src/cmd/lts.rs
+++ b/src/cmd/lts.rs
@@ -16,8 +16,7 @@ impl super::Command for Lts {
         let release = releases.lts()?;
 
         let dwnld = Downloader::new(release, &config);
-        let buf = dwnld.download()?;
-        let dest = dwnld.install(buf)?;
+        let dest = dwnld.download()?;
 
         crate::symlink::symlink_to(&dest, &config.alias_dir().join(&ALIAS))?;
 

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -1,8 +1,7 @@
 use crate::fetcher::Release;
 use crate::symlink::symlink_to;
-use crate::url;
 use crate::{archive::Archive, progress_bar::Bar};
-use crate::{config::Config, url::Dist};
+use crate::{config::Config, url};
 use colored::*;
 use indicatif::HumanBytes;
 use std::path::{Path, PathBuf};
@@ -10,23 +9,30 @@ use std::path::{Path, PathBuf};
 pub struct Downloader<'a> {
     release: &'a Release,
     config: &'a Config,
-    dist: Dist,
+    release_dir: PathBuf,
 }
 
 impl<'a> Downloader<'a> {
     pub fn new(release: &'a Release, config: &'a Config) -> Self {
-        let dist = url::release(&config.dist_mirror, &release.version);
-
         Self {
             release,
             config,
-            dist,
+            release_dir: config.release_dir(),
         }
     }
 
-    pub fn download(&self) -> anyhow::Result<Vec<u8>> {
-        let r = &self.release;
-        let res = ureq::get(&self.dist.url).call()?;
+    pub fn download(&self) -> anyhow::Result<PathBuf> {
+        let v = &self.release.version;
+        let v_str = v.to_string();
+
+        let dest = &self.release_dir.join(&v_str);
+
+        if dest.exists() {
+            anyhow::bail!("Version {} is already exists locally", &v_str.bold());
+        }
+
+        let dist = url::release(&self.config.dist_mirror, &v);
+        let res = ureq::get(&dist.url).call()?;
         let len = res
             .header("Content-Length")
             .and_then(|x| x.parse::<u64>().ok());
@@ -36,8 +42,8 @@ impl<'a> Downloader<'a> {
             None => "unknown".into(),
         };
 
-        println!("Version   : {}", r.version.to_string().bold());
-        println!("Download  : {}", self.dist.url.bold());
+        println!("Version   : {}", v_str.bold());
+        println!("Download  : {}", dist.url.bold());
         println!("Size      : {}", size.bold());
 
         println!();
@@ -46,16 +52,21 @@ impl<'a> Downloader<'a> {
 
         println!();
 
-        Ok(buf)
+        let dest = self.install(buf, dist.name)?;
+
+        Ok(dest)
     }
 
-    pub fn install(&self, buf: Vec<u8>) -> anyhow::Result<PathBuf> {
-        let release_dir = self.config.release_dir();
+    fn install(&self, buf: Vec<u8>, dist: String) -> anyhow::Result<PathBuf> {
+        let release_dir = &self.release_dir;
         let dest = release_dir.join(&self.release.version.to_string());
 
-        Archive::new(buf).extract_into(&release_dir)?;
+        println!("{:#?}", release_dir);
+        println!("{:#?}", dest);
 
-        std::fs::rename(&release_dir.join(&self.dist.name), &dest)?;
+        Archive::new(buf).extract_into(&dest)?;
+
+        std::fs::rename(&release_dir.join(&dist), &dest)?;
 
         println!("Installed : {}", &dest.display().to_string().bold());
 
@@ -93,8 +104,7 @@ impl<'a> Downloader<'a> {
 //         let download_path_expected = dir.join(release.version.to_string());
 //         let download_path_result = {
 //             let dwnld = Downloader::new(&release, &config);
-//             let buf = dwnld.download()?;
-//             dwnld.install(buf)?
+//             dwnld.download()?
 //         };
 //
 //         assert_eq!(download_path_expected, download_path_result);


### PR DESCRIPTION
This check was accidentally removed while refactoring the downloader. Now it is fixed, but sadly I need to make some changes that I am not happy about :(