### PR TITLE
change: rename `prune` to `purge`

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,15 @@ snm exec 10 -- node -v
 snm exec 10 -- yarn start
 ```
 
--   `snm prune` : Remove all downloaded versions except the installed version
+-   `snm purge` : Remove all the installed versions and aliases. Except the active version.
+
+```
+# Doesn't remove the active version
+snm purge
+
+# Will remove everything including the active version
+snm purge --all
+```
 
 -   `snm which <version>` : Prints path for the downloaded Nodejs version
 

--- a/src/cli/subcommand.rs
+++ b/src/cli/subcommand.rs
@@ -1,5 +1,5 @@
 use crate::commands::{
-    alias, completions, env, exec, install, latest, ls, ls_remote, lts, prune, r#use, unalias,
+    alias, completions, env, exec, install, latest, ls, ls_remote, lts, purge, r#use, unalias,
     uninstall, which, Command,
 };
 use clap::Subcommand;
@@ -49,13 +49,14 @@ pub enum SubCommand {
     #[clap(visible_alias = "lsr")]
     LsRemote(ls_remote::LsRemote),
 
-    /// Output path for installed node <version>
+    /// Output path for installed node version
     Which(which::Which),
 
-    /// Remove all the installed versions except the used version.
+    /// Remove all the installed versions and aliases. By default, active version is not removed.
     ///
     /// NOTE: This will also remove any redundant downloads
-    Prune(prune::Prune),
+    #[clap(visible_alias = "prune")]
+    Purge(purge::Purge),
 
     /// Remove the aliases
     #[clap(name = "unalias", visible_alias = "rma")]
@@ -85,7 +86,7 @@ impl SubCommand {
             Self::Ls(m) => m.init(config),
             Self::LsRemote(m) => m.init(config),
             Self::Which(m) => m.init(config),
-            Self::Prune(m) => m.init(config),
+            Self::Purge(m) => m.init(config),
             Self::UnAlias(m) => m.init(config),
             Self::UnInstall(m) => m.init(config),
         }

--- a/src/cli/subcommand.rs
+++ b/src/cli/subcommand.rs
@@ -42,7 +42,7 @@ pub enum SubCommand {
     /// Install the latest LTS release
     Lts(lts::Lts),
 
-    /// List all the local installed versions with their aliases (if any)
+    /// List all the local installed versions with their aliases
     Ls(ls::Ls),
 
     /// List remote Nodejs versions
@@ -52,22 +52,24 @@ pub enum SubCommand {
     /// Output path for installed node version
     Which(which::Which),
 
-    /// Remove all the installed versions and aliases. By default, active version is not removed.
+    /// Remove everything except the active version.
     ///
     /// NOTE: This will also remove any redundant downloads
     #[clap(visible_alias = "prune")]
     Purge(purge::Purge),
 
-    /// Remove the aliases
+    /// Unlink the alias
+    ///
+    /// NOTE: This only removes the alias and doesn't remove the linked version
     #[clap(name = "unalias", visible_alias = "rma")]
     UnAlias(unalias::UnAlias),
 
-    /// Remove the installed Nodejs with the given version or alias
+    /// Remove the installed version or alias
     ///
     /// Example: snm uninstall 14 | snm uninstall lts-fermium
     ///
     /// NOTE: If given an alias like ten or lts-fermium then it will remove the version that the alias is pointing to and all the aliases which are pointing to the same version.
-    /// Also, If multiple installtion were found for a version, then it will remove the latest.
+    /// Also, If multiple installation were found for a version, then it will remove the latest.
     #[clap(name = "uninstall", visible_alias = "rm")]
     UnInstall(uninstall::UnInstall),
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,7 +7,7 @@ pub mod latest;
 pub mod ls;
 pub mod ls_remote;
 pub mod lts;
-pub mod prune;
+pub mod purge;
 pub mod unalias;
 pub mod uninstall;
 pub mod r#use;


### PR DESCRIPTION
This PR consist of two changes
- Renaming `prune` command to `purge` but also retain `prune` as an alias to `purge`.
- Add `--all` flag to `purge` to also remove the active version.