### PR TITLE
breaking: rename alias `default` to `active`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [0.8.0]
 
+### Breaking
+
+-   Rename active version alias from `default` to `active` [#89](https://github.com/numToStr/snm/pull/89)
+
+> If you are upgrading from an older version, `snm` will not recognize the running version. To fix this just run the `use` command with a version of your choice.
+
 ### Changes
 
 -   Rename `prune` command to `purge` but retain `prune` as an alias [#82](https://github.com/numToStr/snm/pull/82)

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -72,9 +72,7 @@ impl Config {
     }
 
     pub fn alias_default(&self) -> AliasDir {
-        let p = self.alias_dir().as_ref().join(UserAlias::DEFAULT);
-
-        AliasDir::new(p)
+        self.alias_dir().join(UserAlias::ACTIVE)
     }
 
     pub fn bin_path(&self, path: &Path) -> PathBuf {

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -17,7 +17,7 @@ impl super::Command for Ls {
         for version in versions.into_iter() {
             match aliases.get(&version) {
                 Some(a) => {
-                    if a.contains(&UserAlias::DEFAULT.to_string()) {
+                    if a.iter().any(|x| *x == UserAlias::ACTIVE) {
                         println!("> {} \t{}", style(version).bold(), a.join(", "));
                     } else {
                         println!("- {} \t{}", version, a.join(", "));

--- a/src/commands/purge.rs
+++ b/src/commands/purge.rs
@@ -31,7 +31,7 @@ impl super::Command for Purge {
         if !default_alias.as_ref().exists() {
             anyhow::bail!(
                 "Unable to prune. No {} alias found",
-                style(UserAlias::DEFAULT).bold()
+                style(UserAlias::ACTIVE).bold()
             );
         }
 

--- a/src/commands/purge.rs
+++ b/src/commands/purge.rs
@@ -37,7 +37,7 @@ impl super::Command for Purge {
 
         let release_dir = config.release_dir();
 
-        let used_ver = Linker::read_convert_to_dist(&default_alias, &release_dir)?;
+        let active_ver = Linker::read_convert_to_dist(&default_alias, &release_dir)?;
 
         // Nuke the alias directory after reading the default alias
         remove_dir_all(config.alias_dir().as_ref())?;
@@ -49,7 +49,7 @@ impl super::Command for Purge {
         let dist_versions = DistVersion::list_versions(&release_dir)?;
         for version in dist_versions {
             // If the version is currently active then don't delete
-            if version.eq(&used_ver) {
+            if version.eq(&active_ver) {
                 continue;
             }
 
@@ -63,7 +63,7 @@ impl super::Command for Purge {
         // Restoring the default alias
         // NOTE: don't use the `default_alias` variable
         Linker::create_link(
-            &release_dir.join(used_ver.to_string()),
+            &release_dir.join(active_ver.to_string()),
             &config.alias_default(),
         )?;
 

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -33,7 +33,7 @@ impl super::Command for UnInstall {
                     anyhow::bail!("Codename {} not found", style(lts_code).bold());
                 }
 
-                Linker::read_convert_to_dist(&alias_dir, &release_dir)?
+                Linker::read_convert_to_dist(&alias_ver, &release_dir)?
             }
             UserVersion::Alias(alias) => {
                 let alias_ver = alias_dir.join(alias.as_ref());
@@ -42,7 +42,7 @@ impl super::Command for UnInstall {
                     anyhow::bail!("Alias {} not found", style(alias).bold());
                 }
 
-                Linker::read_convert_to_dist(&alias_dir, &release_dir)?
+                Linker::read_convert_to_dist(&alias_ver, &release_dir)?
             }
             x => DistVersion::match_version(&release_dir, x)?,
         };
@@ -52,7 +52,7 @@ impl super::Command for UnInstall {
         let aliases = Linker::list_for_version(&version, &alias_dir, &release_dir)?;
 
         // Checking whether the version is currently used or not
-        let is_default = aliases.iter().any(|x| x.as_str() == UserAlias::DEFAULT);
+        let is_default = aliases.iter().any(|x| *x == UserAlias::ACTIVE);
 
         if is_default && self.no_used {
             anyhow::bail!(

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -13,9 +13,9 @@ pub struct UnInstall {
     /// Semver, Alias or Lts codename that needs to be removed
     version: UserVersion,
 
-    /// Don't remove if the version is currently used.
+    /// Don't remove if the version is currently active.
     #[clap(short = 'N', long)]
-    no_used: bool,
+    no_active: bool,
 }
 
 impl super::Command for UnInstall {
@@ -51,12 +51,12 @@ impl super::Command for UnInstall {
         // then remove them all the aliases before removing the actuall installed version
         let aliases = Linker::list_for_version(&version, &alias_dir, &release_dir)?;
 
-        // Checking whether the version is currently used or not
+        // Checking whether the version is currently active or not
         let is_default = aliases.iter().any(|x| *x == UserAlias::ACTIVE);
 
-        if is_default && self.no_used {
+        if is_default && self.no_active {
             anyhow::bail!(
-                "Unable to uninstall. Version {} is currently used!",
+                "Unable to uninstall. Version {} is currently active!",
                 style(version).bold()
             );
         }

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -11,7 +11,7 @@ use snm_core::{
 #[derive(Debug, Clap)]
 pub struct UnInstall {
     /// Semver, Alias or Lts codename that needs to be removed
-    version_or_alias: UserVersion,
+    version: UserVersion,
 
     /// Don't remove if the version is currently used.
     #[clap(short = 'N', long)]
@@ -25,7 +25,7 @@ impl super::Command for UnInstall {
 
         // first we need to find out the whether the provided version is an alias, lts codename or partial semver
         // If the version is alias or codename, then we need to find the linked/installed version
-        let version = match &self.version_or_alias {
+        let version = match &self.version {
             UserVersion::Lts(lts_code) => {
                 let alias_ver = alias_dir.join(&lts_code.to_string());
 

--- a/src/lib/types.rs
+++ b/src/lib/types.rs
@@ -4,6 +4,8 @@ use std::{
     str::FromStr,
 };
 
+use console::style;
+
 macro_rules! as_ref {
     ($impl: ident, $ty: ty) => {
         impl AsRef<$ty> for $impl {
@@ -72,6 +74,10 @@ impl Display for UserAlias {
 impl FromStr for UserAlias {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == Self::DEFAULT {
+            anyhow::bail!("{} is not allowed", style(Self::DEFAULT).bold())
+        }
+
         Ok(Self::new(s))
     }
 }

--- a/src/lib/types.rs
+++ b/src/lib/types.rs
@@ -54,7 +54,7 @@ as_ref!(UserLts, str);
 pub struct UserAlias(String);
 
 impl UserAlias {
-    pub const DEFAULT: &'static str = "default";
+    pub const ACTIVE: &'static str = "active";
 
     pub fn new(s: &str) -> Self {
         Self(s.replace('/', "-").replace('\\', "-"))

--- a/src/lib/types.rs
+++ b/src/lib/types.rs
@@ -74,8 +74,8 @@ impl Display for UserAlias {
 impl FromStr for UserAlias {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == Self::DEFAULT {
-            anyhow::bail!("{} is not allowed", style(Self::DEFAULT).bold())
+        if s == Self::ACTIVE {
+            anyhow::bail!("{} is not allowed", style(Self::ACTIVE).bold())
         }
 
         Ok(Self::new(s))

--- a/src/lib/version/user_version.rs
+++ b/src/lib/version/user_version.rs
@@ -54,7 +54,8 @@ impl ParseVersion for UserVersion {
             } else if UserLts::is_lts(v) {
                 Self::Lts(UserLts::new(v))
             } else {
-                Self::Alias(UserAlias::new(v))
+                // from_str method is used bcz it returns err if the given alias is same as active alias
+                Self::Alias(UserAlias::from_str(v)?)
             }
         };
 


### PR DESCRIPTION
Before, the name of the alias which was currently running was `default`. Now, it is renamed to `active`. Also, `snm` will now throw an error if the user is providing the active alias name to a command which supports version/alias as an input.