### PR TITLE
change: don't allow uninstalling the active version by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,17 +154,19 @@ snm install lts/fermium
 
 -   `snm uninstall [version|alias]` : Removes the installed Nodejs
 
-> If given an alias like `ten` or `lts-fermium` then it will remove the version which the alias is pointing at and all the aliases which are pointing to the same version.
-> Also, uninstalling a version will throw an error, if multiple installation is found in the same semver range
+> If given an alias like `ten` or `lts-fermium` then it will remove the version which the alias is pointing at and all the aliases which are pointing to the same version. Also, uninstalling a version will throw an error, if multiple installation is found in the same semver range or if the provided version/alias is active, add `--force` flag to override this behaviour.
 
 ```sh
 # Following command will remove 14.x.x installation
 snm uninstall 14
 
-# Following command will download the most recent lts/fermium release
+# Following command will remove the lts/fermium release
 snm uninstall lts/fermium
 # or snm uninstall lts-fermium
 # or snm rm lts-fermium
+
+# Add --force flag to forcefully remove the active version
+snm uninstall --force 16
 ```
 
 -   `snm use [version]` : Change Nodejs version, Supports `.nvmrc` and `.node-version`

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ snm install lts/fermium
 
 -   `snm uninstall [version|alias]` : Removes the installed Nodejs
 
-> If given an alias like `ten` or `lts-fermium` then it will remove the version which the alias is pointing at and all the aliases which are pointing to the same version. Also, uninstalling a version will throw an error, if multiple installation is found in the same semver range or if the provided version/alias is active, add `--force` flag to override this behaviour.
+> If given an alias like `ten` or `lts-fermium` then it will remove the version which the alias is pointing at and all the aliases which are pointing to the same version. Also, uninstalling a version will throw an error, if multiple installation is found in the same semver range or if the provided version/alias is active, add `--force` flag to override this behavior.
 
 ```sh
 # Following command will remove 14.x.x installation

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -13,9 +13,9 @@ pub struct UnInstall {
     /// Semver, Alias or Lts codename that needs to be removed
     version: UserVersion,
 
-    /// Don't remove if the version is currently active.
-    #[clap(short = 'N', long)]
-    no_active: bool,
+    /// Forcefull remove the active version
+    #[clap(short, long)]
+    force: bool,
 }
 
 impl super::Command for UnInstall {
@@ -54,7 +54,7 @@ impl super::Command for UnInstall {
         // Checking whether the version is currently active or not
         let is_default = aliases.iter().any(|x| *x == UserAlias::ACTIVE);
 
-        if is_default && self.no_active {
+        if is_default && !self.force {
             anyhow::bail!(
                 "Unable to uninstall. Version {} is currently active!",
                 style(version).bold()

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -56,7 +56,7 @@ impl super::Command for UnInstall {
 
         if is_default && !self.force {
             anyhow::bail!(
-                "Unable to uninstall! Version {} is currently active. Add --force to override this behaviour",
+                "Unable to uninstall! Version {} is currently active. Add --force to override this behavior",
                 style(version).bold()
             );
         }

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -13,7 +13,7 @@ pub struct UnInstall {
     /// Semver, Alias or Lts codename that needs to be removed
     version: UserVersion,
 
-    /// Forcefull remove the active version
+    /// Forcefully remove the active version
     #[clap(short, long)]
     force: bool,
 }

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -56,7 +56,7 @@ impl super::Command for UnInstall {
 
         if is_default && !self.force {
             anyhow::bail!(
-                "Unable to uninstall. Version {} is currently active!",
+                "Unable to uninstall! Version {} is currently active. Add --force to override this behaviour",
                 style(version).bold()
             );
         }


### PR DESCRIPTION
This is the inverse of the old behavior where the active version is removed by default, which can be prevented by using the `--no-used` flag. But now, the active version is not removed by default and but can be overridden by the `--force` flag.