### PR TITLE
Fix installation script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -79,12 +79,7 @@ download_snm() {
   # if [ "$USE_HOMEBREW" == "true" ]; then
   #   brew install snm
   # else
-    if [ "$RELEASE" == "latest" ]; then
-      URL="https://github.com/numToStr/snm/releases/latest/download/$FILENAME.tar.gz"
-    else
-      URL="https://github.com/numToStr/snm/releases/download/$RELEASE/$FILENAME.tar.gz"
-    fi
-
+    URL="https://github.com/numToStr/snm/releases/download/$RELEASE/$FILENAME.tar.gz"
     DOWNLOAD_DIR=$(mktemp -d)
 
     echo "Downloading $URL..."


### PR DESCRIPTION
Script had syntax error because one line wasn't commented. 
Another problem was: filenames weren't correct because they contains release version. 

Now script gets correct filenames