### PR TITLE
change: remove redundant shell variables

### DIFF
--- a/a.txt
+++ b/a.txt
@@ -1,0 +1,2 @@
+- Move env variable to default
+- Add `silent` to `use` so that I won't print everytime on `--use-on-cd`

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,7 +1,6 @@
 use clap::Parser;
-use dirs_next::home_dir;
 use snm_core::{
-    types::{AliasDir, DownloadDir, ReleaseDir, UserAlias},
+    types::{AliasDir, DownloadDir, ReleaseDir, SnmDir, UserAlias},
     MIRROR,
 };
 use std::{
@@ -13,8 +12,14 @@ use url::Url;
 #[derive(Parser, Debug)]
 pub struct Config {
     /// Root directory of the snm installation
-    #[clap(long, name = "base-dir", env = "SNM_DIR", global = true)]
-    pub snm_dir: Option<PathBuf>,
+    #[clap(
+        long,
+        name = "base-dir",
+        env = "SNM_DIR",
+        global = true,
+        default_value_t
+    )]
+    pub snm_dir: SnmDir,
 
     /// Nodejs release mirror
     #[clap(
@@ -47,26 +52,20 @@ impl Config {
         path
     }
 
-    pub fn snm_home(&self) -> PathBuf {
-        self.snm_dir
-            .to_owned()
-            .unwrap_or_else(|| home_dir().expect("Can't get home directory.").join(".snm"))
-    }
-
     pub fn release_dir(&self) -> ReleaseDir {
-        let p = self.ensure_create(self.snm_home().join("releases"));
+        let p = self.ensure_create(self.snm_dir.as_ref().join("releases"));
 
         ReleaseDir::new(p)
     }
 
     pub fn alias_dir(&self) -> AliasDir {
-        let p = self.ensure_create(self.snm_home().join("aliases"));
+        let p = self.ensure_create(self.snm_dir.as_ref().join("aliases"));
 
         AliasDir::new(p)
     }
 
     pub fn download_dir(&self) -> DownloadDir {
-        let p = self.ensure_create(self.snm_home().join("downloads"));
+        let p = self.ensure_create(self.snm_dir.as_ref().join("downloads"));
 
         DownloadDir::new(p)
     }

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -35,16 +35,6 @@ impl super::Command for Env {
 
         // println!("{}", shell.env_var("SNM_LOGLEVEL", &config.log_level));
 
-        println!(
-            "{}",
-            shell.env_var("SNM_DIR", &config.snm_home().display().to_string())
-        );
-
-        println!(
-            "{}",
-            shell.env_var("SNM_NODE_DIST_MIRROR", &config.dist_mirror.to_string())
-        );
-
         if self.use_on_cd {
             println!("{}", shell.use_on_cd());
         }

--- a/src/commands/purge.rs
+++ b/src/commands/purge.rs
@@ -15,7 +15,7 @@ impl super::Command for Purge {
     fn init(self, config: Config) -> SnmRes<()> {
         // If all=true then nuke the snm home directory
         if self.all {
-            let snm_home = config.snm_home();
+            let snm_home = config.snm_dir.as_ref();
 
             if snm_home.exists() {
                 remove_dir_all(snm_home)?;

--- a/src/lib/types.rs
+++ b/src/lib/types.rs
@@ -1,4 +1,5 @@
 use std::{
+    convert::Infallible,
     fmt::{self, Display, Formatter},
     path::{Path, PathBuf},
     str::FromStr,
@@ -114,3 +115,33 @@ pub struct DownloadDir(PathBuf);
 as_ref!(DownloadDir, PathBuf);
 
 neww!(DownloadDir);
+
+/// snm home directory
+#[derive(Debug)]
+pub struct SnmDir(PathBuf);
+
+as_ref!(SnmDir, PathBuf);
+
+impl Default for SnmDir {
+    fn default() -> Self {
+        Self(
+            dirs_next::home_dir()
+                .expect("Can't get home directory.")
+                .join(".snm"),
+        )
+    }
+}
+
+impl Display for SnmDir {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.display())
+    }
+}
+
+impl FromStr for SnmDir {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let path = PathBuf::from_str(s)?;
+        Ok(Self(path))
+    }
+}


### PR DESCRIPTION
Now `--snm-dir` and `--node-dist-mirror` always has a default value, so
there is no point in having shell variables for providing a default value.